### PR TITLE
refactor: use active-model 2

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rethinkdb-orm
-version: 2.10.1
+version: 3.0.0
 license: MIT
 
 authors:
@@ -8,6 +8,7 @@ authors:
 dependencies:
   active-model:
     github: spider-gazelle/active-model
+    version: ~> 2
   future:
     github: crystal-community/future.cr
   habitat:

--- a/spec/associations_spec.cr
+++ b/spec/associations_spec.cr
@@ -25,6 +25,7 @@ describe RethinkORM::Associations do
         child = Child.new(age: age)
         child.parent = parent
         child = child.save!
+
         child.persisted?.should be_true
         parent.id.should eq child.parent_id
 
@@ -57,7 +58,7 @@ describe RethinkORM::Associations do
       coffee.destroy
 
       # Ensure owner association deleted
-      Programmer.exists?(programmer.id.not_nil!).should be_false
+      Programmer.exists?(programmer.id.as(String)).should be_false
     end
 
     it "#has_one" do
@@ -71,8 +72,8 @@ describe RethinkORM::Associations do
       programmer.destroy
 
       # Ensure both owner and dependent deleted
-      Friend.exists?(friend.id.not_nil!).should be_false
-      Programmer.exists?(programmer.id.not_nil!).should be_false
+      Friend.exists?(friend.id.as(String)).should be_false
+      Programmer.exists?(programmer.id.as(String)).should be_false
     end
 
     it "#has_many" do
@@ -99,7 +100,7 @@ describe RethinkORM::Associations do
       car.destroy
 
       # Ensure that parent has been destroyed
-      Car.exists?(car.id.not_nil!).should be_false
+      Car.exists?(car.id.as(String)).should be_false
 
       # Ensure no children persist in the db
       car.wheels.to_a.empty?.should be_true
@@ -112,7 +113,7 @@ describe RethinkORM::Associations do
     coffee.programmer = programmer
     coffee.save
 
-    Coffee.by_programmer_id(programmer.id.not_nil!).first.should eq coffee
+    Coffee.by_programmer_id(programmer.id.as(String)).first.should eq coffee
 
     coffee.destroy
     programmer.destroy
@@ -123,11 +124,11 @@ describe RethinkORM::Associations do
     child = Child.create!(age: 29, parent_id: parent.id)
 
     child.delete
-    Child.exists?(child.id.not_nil!).should be_false
-    Parent.exists?(parent.id.not_nil!).should be_true
+    Child.exists?(child.id.as(String)).should be_false
+    Parent.exists?(parent.id.as(String)).should be_true
 
     parent.delete
-    Parent.exists?(parent.id.not_nil!).should be_false
+    Parent.exists?(parent.id.as(String)).should be_false
   end
 
   it "should cache associations" do
@@ -143,7 +144,7 @@ describe RethinkORM::Associations do
     # reload triggers reset of cached associations
     child.reload!
 
-    child.parent.should eq nil
+    child.parent.should be_nil
     child.destroy
   end
 

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -22,7 +22,7 @@ describe RethinkORM::Base do
   it "should load database responses" do
     base = BasicModel.create(name: "joe")
 
-    base_found = BasicModel.find!(base.id.not_nil!)
+    base_found = BasicModel.find!(base.id.as(String))
 
     base_found.id.should eq base.id
     base_found.should eq base
@@ -32,8 +32,8 @@ describe RethinkORM::Base do
 
   it "should support serialisation" do
     base = BasicModel.create(name: "joe")
-    base_id = base.id.not_nil!
-    base.to_json.should eq ({name: "joe", id: base_id}.to_json)
+    base_id = base.id
+    base.to_json.should eq ({name: "joe", age: 0, id: base_id}.to_json)
 
     base.destroy
   end
@@ -41,10 +41,10 @@ describe RethinkORM::Base do
   it "should support dirty attributes" do
     begin
       base = BasicModel.new
-      base.changed_attributes.empty?.should be_true
+      changed_attributes = base.changed_attributes
 
       base.name = "change"
-      base.changed_attributes.empty?.should be_false
+      base.changed_attributes.size.should eq (changed_attributes.size + 1)
 
       base = BasicModel.new(name: "bob")
       base.changed_attributes.empty?.should be_false

--- a/spec/changefeed_spec.cr
+++ b/spec/changefeed_spec.cr
@@ -19,7 +19,9 @@ module RethinkORM
         end
       end
 
-      base.update(name: "stimpy")
+      base.name = "stimpy"
+      base.save
+
       coordination.receive
       changes.should eq [{:name => "stimpy"}]
 
@@ -89,7 +91,9 @@ module RethinkORM
           end
         end
 
-        base.update(name: "stimpy")
+        base.name = "stimpy"
+        base.save
+
         updated_json = JSON.parse base.to_json
 
         coordination.receive

--- a/spec/queries_spec.cr
+++ b/spec/queries_spec.cr
@@ -15,14 +15,14 @@ describe RethinkORM::Queries do
 
   it "#find!" do
     model = BasicModel.create!(name: Faker::Name.name)
-    found_model = BasicModel.find!(model.id.not_nil!)
+    found_model = BasicModel.find!(model.id.as(String))
 
     found_model.id.should eq model.id
   end
 
   it "#exists?" do
     model = BasicModel.create!(name: Faker::Name.name)
-    BasicModel.exists?(model.id.not_nil!).should be_true
+    BasicModel.exists?(model.id.as(String)).should be_true
   end
 
   describe "#find_all" do
@@ -147,7 +147,7 @@ describe RethinkORM::Queries do
     }
 
     # Check the correct
-    get_tree_ids.call(roots[0]).should eq [tree_ids[0]]
+    get_tree_ids.call(roots.first).should eq [tree_ids.first]
     get_tree_ids.call(roots[1]).should eq tree_ids.sort
     get_tree_ids.call(roots[2]).should eq [tree_ids[1]]
   end

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -5,19 +5,19 @@ require "../src/rethinkdb-orm/**"
 
 class BasicModel < RethinkORM::Base
   attribute name : String
-  attribute address : String
-  attribute age : Int32
+  attribute address : String?
+  attribute age : Int32 = 0
 end
 
 class ModelWithDefaults < RethinkORM::Base
   attribute name : String = "bob"
-  attribute address : String
+  attribute address : String?
   attribute age : Int32 = 23
 end
 
 class ModelWithCallbacks < RethinkORM::Base
   attribute name : String
-  attribute address : String
+  attribute address : String?
   attribute age : Int32 = 10
 
   before_create :update_name
@@ -43,7 +43,7 @@ end
 
 class ModelWithValidations < RethinkORM::Base
   attribute name : String
-  attribute address : String
+  attribute address : String?
   attribute age : Int32 = 10
 
   validates :name, presence: true
@@ -62,19 +62,19 @@ end
 
 # Association Models
 
-class Fruit < RethinkORM::Base
-  attribute type : String
-  belongs_to Orchard, association_name: :orchy
-end
-
 class Orchard < RethinkORM::Base
   attribute name : String
   has_one Fruit, association_name: :froot
 end
 
+class Fruit < RethinkORM::Base
+  attribute type : String
+  belongs_to Orchard, association_name: :orchy
+end
+
 class Car < RethinkORM::Base
   attribute brand : String
-  attribute vin : String
+  attribute vin : String = UUID.random.to_s
 
   secondary_index :vin
   has_many Wheel, collection_name: "wheels", dependent: :destroy
@@ -140,12 +140,12 @@ end
 # Validation models
 
 class Snowflake < RethinkORM::Base
-  attribute shape : String
-  attribute meltiness : Int32
-  attribute personality : String
-  attribute taste : String
-  attribute vibe : String
-  attribute size : Int32
+  attribute shape : String = UUID.random.to_s
+  attribute meltiness : Int32 = Random.rand(100).to_i
+  attribute personality : String = UUID.random.to_s
+  attribute taste : String = UUID.random.to_s
+  attribute vibe : String = UUID.random.to_s
+  attribute size : Int32 = 0
 
   ensure_unique :meltiness
   ensure_unique :shape, callback: :id

--- a/spec/table_spec.cr
+++ b/spec/table_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe RethinkORM::Table do
   it "produces a table name from the class" do
     model = BasicModel.create!(name: "Wallace")
-    id = model.id || ""
+    id = model.id.as(String)
     id.should start_with "basic_model"
     result = RethinkORM::Connection.raw do |q|
       q.table_list.contains("basic_model")
@@ -13,7 +13,7 @@ describe RethinkORM::Table do
 
   it "allows overriding of default table name" do
     model = UnneccesarilyLongNameThatWillProduceAStupidTableName.create!(why: "not")
-    id = model.id || ""
+    id = model.id.as(String)
     id.should start_with "mod"
     result = RethinkORM::Connection.raw do |q|
       q.table_list.contains("mod")

--- a/spec/timestamps_spec.cr
+++ b/spec/timestamps_spec.cr
@@ -6,8 +6,8 @@ describe RethinkORM::Timestamps do
 
     model.created_at.should be_a(Time)
     model.updated_at.should be_a(Time)
-    model.created_at.not_nil!.should eq model.updated_at.not_nil!
-    model.created_at.not_nil!.should be < Time.utc
+    model.created_at.should eq model.updated_at
+    model.created_at.should be < Time.utc
 
     model.destroy
   end
@@ -17,17 +17,19 @@ describe RethinkORM::Timestamps do
 
     model.created_at.should be_a(Time)
     model.updated_at.should be_a(Time)
-    model.created_at.not_nil!.should eq model.updated_at
+    model.created_at.should eq model.updated_at
 
     sleep 2
 
-    model.update(name: "Timooooo?")
-    model.updated_at.not_nil!.should_not eq model.created_at
-    model.updated_at.not_nil!.should be > model.created_at.not_nil!
+    model.name = "Timooooo?"
+    model.save
 
-    found_model = Timo.find!(model.id.not_nil!)
-    found_model.updated_at.not_nil!.should be_close(model.updated_at.not_nil!, delta: Time::Span.new(seconds: 1, nanoseconds: 0))
-    found_model.updated_at.not_nil!.should_not be_close(model.created_at.not_nil!, delta: Time::Span.new(seconds: 1, nanoseconds: 0))
+    model.updated_at.should_not eq model.created_at
+    model.updated_at.should be > model.created_at
+
+    found_model = Timo.find!(model.id.as(String))
+    found_model.updated_at.should be_close(model.updated_at, delta: Time::Span.new(seconds: 1, nanoseconds: 0))
+    found_model.updated_at.should_not be_close(model.created_at, delta: Time::Span.new(seconds: 1, nanoseconds: 0))
 
     model.destroy
   end

--- a/spec/unique_spec.cr
+++ b/spec/unique_spec.cr
@@ -2,6 +2,10 @@ require "./spec_helper"
 
 describe RethinkORM::Validators do
   context "Unique" do
+    Spec.before_each do
+      Snowflake.clear
+    end
+
     it "invalidates models with non-unique fields" do
       special_snowflake = Snowflake.create!(shape: "fernlike stellar dendrites", meltiness: 0)
       less_special_snowflake = Snowflake.new(shape: "fernlike stellar dendrites", meltiness: 2)
@@ -9,14 +13,14 @@ describe RethinkORM::Validators do
       special_snowflake.valid?.should be_true
       less_special_snowflake.valid?.should be_false
 
-      less_special_snowflake.errors[0].to_s.should eq "Snowflake shape should be unique"
+      less_special_snowflake.errors.first.to_s.should eq "Snowflake shape should be unique"
     end
 
     it "validates if the model is the same" do
       special_snowflake = Snowflake.create!(shape: "a super special snowflake", meltiness: 5)
       same_flake = Snowflake.find(special_snowflake.id.not_nil!)
 
-      same_flake.should_not eq nil
+      same_flake.should_not be_nil
       unless same_flake.nil?
         same_flake.meltiness = 1000
         same_flake.valid?.should be_true
@@ -27,28 +31,31 @@ describe RethinkORM::Validators do
 
     it "accepts a transform block for the field" do
       special_snowflake = Snowflake.create!(personality: "GENTLE")
-      louder_snowflake = Snowflake.new(personality: "gentle")
+
+      louder_snowflake = Snowflake.new(personality: "gentle", shape: "square", taste: "weak", vibe: "atrocious")
 
       special_snowflake.valid?.should be_true
       louder_snowflake.valid?.should be_false
 
-      louder_snowflake.errors[0].to_s.should eq "Snowflake personality should be unique"
+      louder_snowflake.errors.first.to_s.should eq "Snowflake personality should be unique"
     end
 
     it "passes scoped fields to transform block" do
-      fresh_flake = Snowflake.new(vibe: "awful", taste: "GREAT")
+      fresh_flake = Snowflake.new(taste: "GREAT", vibe: "rotten")
       fresh_flake.taste.should eq "GREAT"
+
       fresh_flake.valid?.should be_true
       fresh_flake.taste.should eq "great"
       fresh_flake.save!
 
-      less_fresh = Snowflake.new(vibe: "awful", taste: "great")
+      less_fresh = Snowflake.new(taste: "great", vibe: "rotten")
       less_fresh.valid?.should be_false
-      less_fresh.errors[0].to_s.should eq "Snowflake taste should be unique"
+      less_fresh.errors.first.to_s.should eq "Snowflake taste should be unique"
     end
 
     it "passes scoped fields to transform callback" do
       fresh_flake = Snowflake.new(vibe: "AWFUL", size: 123)
+
       fresh_flake.vibe.should eq "AWFUL"
       fresh_flake.valid?.should be_true
       fresh_flake.vibe.should eq "awful"
@@ -56,7 +63,7 @@ describe RethinkORM::Validators do
 
       less_fresh = Snowflake.new(vibe: "awful", size: 123)
       less_fresh.valid?.should be_false
-      less_fresh.errors[0].to_s.should eq "Snowflake vibe should be unique"
+      less_fresh.errors.first.to_s.should eq "Snowflake vibe should be unique"
     end
   end
 end

--- a/src/rethinkdb-orm/associations.cr
+++ b/src/rethinkdb-orm/associations.cr
@@ -2,13 +2,13 @@ require "./utils/association_collection"
 
 module RethinkORM::Associations
   # Defines getter and setter for parent relationship
-  macro belongs_to(parent_class, dependent = :none, create_index = true, association_name = nil, foreign_key = nil)
+  macro belongs_to(parent_class, dependent = :none, create_index = true, association_name = nil, foreign_key = nil, presence = false)
     {% parent_name = association_name || parent_class.id.stringify.underscore.downcase.gsub(/::/, "_") %}
     {% foreign_key = (foreign_key || "#{parent_name.id}_id").id %}
     {% association_method = parent_name.id.symbolize %}
     {% assoc_var = "__#{parent_name.id}".id %}
 
-    attribute {{ foreign_key.id }} : String, parent: {{ parent_class.id.stringify }}, es_type: "keyword"
+    attribute {{ foreign_key.id }} : String {% unless presence %} | Nil {% end %}, parent: {{ parent_class.id.stringify }}, es_type: "keyword"
     property {{ assoc_var }} : {{ parent_class }}?
     destroy_callback({{ association_method }}, {{dependent}})
 
@@ -39,7 +39,7 @@ module RethinkORM::Associations
     # Sets the parent relationship
     def {{ parent_name.id }}=(parent : {{ parent_class }})
       self.{{ assoc_var }} = parent
-      self.{{ foreign_key.id }} = parent.id
+      self.{{ foreign_key.id }} = parent.id.as(String)
     end
 
     def reset_associations
@@ -56,13 +56,13 @@ module RethinkORM::Associations
     end
   end
 
-  macro has_one(child_class, dependent = :none, create_index = false, association_name = nil)
+  macro has_one(child_class, dependent = :none, create_index = false, association_name = nil, presence = false)
     {% child = association_name || child_class.id.underscore.downcase.gsub(/::/, "_") %}
     {% assoc_var = "__#{child.id}".id %}
     {% foreign_key = child + "_id" %}
     {% association_method = child.id.symbolize %}
 
-    attribute {{ foreign_key.id }} : String
+    attribute {{ foreign_key.id }} : String {% unless presence %} | Nil {% end %}
     property {{ assoc_var }} : {{ child_class }}?
     destroy_callback({{ association_method }}, {{dependent}})
 

--- a/src/rethinkdb-orm/base.cr
+++ b/src/rethinkdb-orm/base.cr
@@ -34,7 +34,7 @@ abstract class RethinkORM::Base < ActiveModel::Model
   end
 
   # Default primary key
-  attribute id : String, es_type: "keyword", mass_assignment: false
+  attribute id : String?, es_type: "keyword", mass_assignment: false
 
   def_equals attributes, changed_attributes
 end

--- a/src/rethinkdb-orm/lock.cr
+++ b/src/rethinkdb-orm/lock.cr
@@ -17,7 +17,7 @@ module RethinkORM
     table "locks"
 
     # TODO: set to `key_hash` when primary_key supported
-    attribute id : String
+    attribute id : String?
 
     # Key is not an index, PKs are 127 chars.
     attribute key : String

--- a/src/rethinkdb-orm/utils/association_collection.cr
+++ b/src/rethinkdb-orm/utils/association_collection.cr
@@ -1,18 +1,21 @@
 require "../index"
 
 class RethinkORM::AssociationCollection(Owner, Target)
-  def initialize(@owner, foreign_key = nil)
-    @foreign_key = !foreign_key ? "#{Owner.table_name}_id" : foreign_key
-  end
+  private getter owner : Owner
+  private getter foreign_key : String
 
   delegate :find, :find!, to: Target
   forward_missing_to all
 
+  def initialize(@owner, foreign_key = nil)
+    @foreign_key = !foreign_key ? "#{Owner.table_name}_id" : foreign_key
+  end
+
   def all
-    if Target.has_index?(@foreign_key)
-      Target.get_all([owner.id], index: @foreign_key)
+    if Target.has_index?(foreign_key)
+      Target.get_all([owner.id.as(String)], index: foreign_key)
     else
-      Target.where({"#{foreign_key}" => owner.id})
+      Target.where({"#{foreign_key}" => owner.id.as(String)})
     end
   end
 
@@ -20,7 +23,7 @@ class RethinkORM::AssociationCollection(Owner, Target)
   #
   def where(**attrs)
     Target.collection_query do |q|
-      index_query = q.get_all([owner.id.not_nil!], index: foreign_key)
+      index_query = q.get_all([owner.id], index: foreign_key)
 
       attrs_hash = attrs.to_h
       attrs_hash.empty? ? index_query : index_query.filter(attrs_hash)
@@ -30,7 +33,7 @@ class RethinkORM::AssociationCollection(Owner, Target)
   # :ditto:
   def where(**attrs)
     Target.collection_query do |q|
-      index_query = q.get_all([owner.id.not_nil!], index: foreign_key)
+      index_query = q.get_all([owner.id], index: foreign_key)
 
       attrs_hash = attrs.to_h
       attribute_filtered = attrs_hash.empty? ? index_query : index_query.filter(attrs_hash)
@@ -38,7 +41,4 @@ class RethinkORM::AssociationCollection(Owner, Target)
       attribute_filtered.filter { |t| yield t }
     end
   end
-
-  private getter owner : Owner
-  private getter foreign_key : String
 end

--- a/src/rethinkdb-orm/utils/id_generator.cr
+++ b/src/rethinkdb-orm/utils/id_generator.cr
@@ -39,7 +39,7 @@ class RethinkORM::IdGenerator
       converted.push(base[digit])
     end
 
-    converted << base[0] if converted.empty?
+    converted << base.first if converted.empty?
     converted.reverse.join
   end
 end

--- a/src/rethinkdb-orm/validators/unique.cr
+++ b/src/rethinkdb-orm/validators/unique.cr
@@ -28,21 +28,21 @@ module RethinkORM::Validators
           transform_proc : Proc({{ proc_arg_type }}, {{ proc_return_type }}) = ->({{ signature.id }}) { {{ transform.body }} }
 
           result : {{ proc_return_type }} = transform_proc.call(
-            {% for s in scope %}this.{{s.id}}.not_nil!,{% end %}
+            {% for s in scope %}this.{{s.id}},{% end %}
           )
         {% elsif callback %}
           result : {{ proc_return_type }} = this.{{ callback.id }}(
-            {% for s in scope %}this.{{s.id}}.not_nil!,{% end %}
+            {% for s in scope %}this.{{s.id}},{% end %}
           )
         {% else %}
 
           {% if scope.size == 1 %}
             # No transform
             result = {
-              {% for s in scope %}this.{{s.id}}.not_nil!,{% end %}
+              {% for s in scope %}this.{{s.id}},{% end %}
             }
           {% else %}
-            result = {{scope.first.id}}.not_nil!
+            result = {{scope.first.id}}
           {% end %}
         {% end %}
 


### PR DESCRIPTION
Update to active-model v2.
Assignment from `HTTP::Params` is type safe, as is `assign_attributes`.
Getters/setters are correctly typed, raising exceptions if the underlying value is nil, however nil validations are run `on_save`.