### PR TITLE
fix(connection): retry queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,15 @@ RethinkORM::Settings.configure do |settings|
   settings.db = ENV["RETHINKDB_DB"]? || ENV["RETHINKDB_DATABASE"]? || "test"
   settings.user = ENV["RETHINKDB_USER"]? || "admin"
   settings.password = ENV["RETHINKDB_PASSWORD"]? || ""
-  settings.retry_interval = (ENV["RETHINKDB_TIMEOUT"]? || 2).to_i.seconds
-  settings.retry_attempts = ENV["RETHINKDB_RETRIES"]?.try &.to_i
   settings.lock_expire = (ENV["RETHINKDB_LOCK_EXPIRE"]? || 30).to_i.seconds
   settings.lock_timeout = (ENV["RETHINKDB_LOCK_TIMEOUT"]? || 5).to_i.seconds
+  settings.retry_interval = (ENV["RETHINKDB_TIMEOUT"]? || 2).to_i.seconds
+
+  # Driver level reconnection attempts
+  settings.retry_attempts = ENV["RETHINKDB_RETRIES"]?.try &.to_i
+
+  # ORM level query retries
+  settings.query_retries = ENV["RETHINKDB_QUERY_RETRIES"]?.try &.to_i || 10
 end
 ```
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rethinkdb-orm
-version: 3.0.2
+version: 3.0.3
 license: MIT
 
 authors:
@@ -16,6 +16,8 @@ dependencies:
   rethinkdb:
     github: kingsleyh/crystal-rethinkdb
     version: ~> 0.2
+  retriable:
+    github: Sija/retriable.cr
 
 development_dependencies:
   ameba:

--- a/src/rethinkdb-orm/connection.cr
+++ b/src/rethinkdb-orm/connection.cr
@@ -46,7 +46,9 @@ module RethinkORM
     # The block defined query is run and raw results returned.
     def self.raw(**options)
       query = yield R
-      query.run(self.db, **options)
+      Retriable.retry(max_attempts: settings.query_retries, on: IO::Error) do
+        query.run(self.db, **options)
+      end
     end
 
     # Passes query builder and datum term of supplied raw json string

--- a/src/rethinkdb-orm/queries.cr
+++ b/src/rethinkdb-orm/queries.cr
@@ -1,3 +1,5 @@
+require "retriable"
+
 require "./connection"
 require "./utils/collection"
 require "./utils/changefeed"

--- a/src/rethinkdb-orm/settings.cr
+++ b/src/rethinkdb-orm/settings.cr
@@ -9,7 +9,10 @@ module RethinkORM
       setting user : String = ENV["RETHINKDB_USER"]? || "admin"
       setting password : String = ENV["RETHINKDB_PASSWORD"]? || ""
       setting retry_interval : Time::Span = (ENV["RETHINKDB_TIMEOUT"]? || 2).to_i.seconds
+      # Driver level reconnection attempts
       setting retry_attempts : Int32? = ENV["RETHINKDB_RETRIES"]?.try &.to_i
+      # ORM level query retries
+      setting query_retries : Int32 = ENV["RETHINKDB_QUERY_RETRIES"]?.try &.to_i || 10
       setting lock_expire : Time::Span = (ENV["RETHINKDB_LOCK_EXPIRE"]? || 30).to_i.seconds
       setting lock_timeout : Time::Span = (ENV["RETHINKDB_LOCK_TIMEOUT"]? || 5).to_i.seconds
     end


### PR DESCRIPTION
Adds a retry block catching IO errors around queries to rethinkdb. 