### PR TITLE
fix(connection): check connection closed before yielding

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rethinkdb-orm
-version: 3.1.1
+version: 3.1.2
 license: MIT
 
 authors:


### PR DESCRIPTION
Reopen `RethinkDB::Connection` to add a check for whether the socket is open, and clean up the connection getter.