### PR TITLE
Add 'foreign_key_type' to association macros

### DIFF
--- a/src/rethinkdb-orm/associations.cr
+++ b/src/rethinkdb-orm/associations.cr
@@ -2,13 +2,13 @@ require "./utils/association_collection"
 
 module RethinkORM::Associations
   # Defines getter and setter for parent relationship
-  macro belongs_to(parent_class, dependent = :none, create_index = true, association_name = nil, foreign_key = nil, presence = false)
+  macro belongs_to(parent_class, dependent = :none, create_index = true, association_name = nil, foreign_key = nil, foreign_key_type = nil, presence = false)
     {% parent_name = association_name || parent_class.id.stringify.underscore.downcase.gsub(/::/, "_") %}
     {% foreign_key = (foreign_key || "#{parent_name.id}_id").id %}
     {% association_method = parent_name.id.symbolize %}
     {% assoc_var = "__#{parent_name.id}".id %}
 
-    attribute {{ foreign_key.id }} : String {% unless presence %} | Nil {% end %}, parent: {{ parent_class.id.stringify }}, es_type: "keyword"
+    attribute {{ foreign_key.id }} : {{ foreign_key_type || String }} {% unless presence %} | Nil {% end %}, parent: {{ parent_class.id.stringify }}, es_type: "keyword"
     property {{ assoc_var }} : {{ parent_class }}?
     destroy_callback({{ association_method }}, {{dependent}})
 
@@ -39,7 +39,7 @@ module RethinkORM::Associations
     # Sets the parent relationship
     def {{ parent_name.id }}=(parent : {{ parent_class }})
       self.{{ assoc_var }} = parent
-      self.{{ foreign_key.id }} = parent.id.as(String)
+      self.{{ foreign_key.id }} = parent.id.as({{ foreign_key_type || String }})
     end
 
     def reset_associations
@@ -56,13 +56,13 @@ module RethinkORM::Associations
     end
   end
 
-  macro has_one(child_class, dependent = :none, create_index = false, association_name = nil, presence = false)
+  macro has_one(child_class, dependent = :none, create_index = false, association_name = nil, foreign_key_type = nil, presence = false)
     {% child = association_name || child_class.id.underscore.downcase.gsub(/::/, "_") %}
     {% assoc_var = "__#{child.id}".id %}
     {% foreign_key = child + "_id" %}
     {% association_method = child.id.symbolize %}
 
-    attribute {{ foreign_key.id }} : String {% unless presence %} | Nil {% end %}
+    attribute {{ foreign_key.id }} : {{ foreign_key_type || String }} {% unless presence %} | Nil {% end %}
     property {{ assoc_var }} : {{ child_class }}?
     destroy_callback({{ association_method }}, {{dependent}})
 

--- a/src/rethinkdb-orm/associations.cr
+++ b/src/rethinkdb-orm/associations.cr
@@ -1,17 +1,45 @@
 require "./utils/association_collection"
 
 module RethinkORM::Associations
-  # Defines getter and setter for parent relationship
-  macro belongs_to(assoc, dependent = :none, create_index = true, foreign_key = nil, foreign_type = nil, primary_key = nil, presence = false)
+  # Specifies a one-to-one association with another class. This method should only be used if this class
+  # contains the foreign key.
+  #
+  # Properties:
+  # `assoc`
+  # :    the method name and type (`name : Type`). An additional field will be created on the model
+  #      called {{ method_name }}_id which will correspond to the parent class' ID.
+  #
+  # `dependent`
+  # :    What do do when the parent record is destroyed. Valid options are `:cascade`, `:destroy`, or `:none`
+  #
+  # `create_index`
+  # :    Whether or not to tag this record as a secondary index.
+  #
+  # `foreign_key`
+  # :    Specify the foreign key used for the association. By default this is guessed to be the name of
+  #      the association with an `_id` suffix. So a class that defines a `belongs_to Person` association
+  #      will use `person_id` as the default foreign_key. Similarly, `belongs_to favorite_person : Person`,
+  #      will use a foreign key of `favorite_person_id`.
+  #
+  # `primary_key`
+  # :    Specify the method that returns the primary key of associated object used for the association.
+  #      By default this is `id`.
+  #
+  # `primary_type`
+  # :    Specify the class of the `primary_key` if it is not `String` (the default).
+  #
+  macro belongs_to(assoc, dependent = :none, create_index = true, foreign_key = nil, primary_key = nil, primary_type = nil, dbg = false)
     {% method_name = assoc.var %}
-    {% class_name = assoc.type %}
+    {% class_name = assoc.type.stringify.split(" | ").first.id %}
+    {% presence = !assoc.type.stringify.ends_with?("Nil") %}
     {% foreign_key ||= method_name.id + "_id" %}
-    {% foreign_type ||= String %}
+    {% primary_type ||= String %}
     {% primary_key ||= "id".id %}
-    {% assoc_var = "__#{foreign_key.id}".id %}
+    {% assoc_var = "__#{method_name.id}".id %}
 
-    attribute {{ foreign_key.id }} : {{ foreign_type }} {% unless presence %} | Nil {% end %}, parent: {{ class_name.id.stringify }}, es_type: "keyword"
-    property {{ assoc_var }} : {{ class_name }}?
+    @{{ assoc_var }} : {{ class_name }}?
+    attribute {{ foreign_key.id }} : {{ primary_type }}{% unless presence %} | Nil{% end %}, parent: {{ class_name.id.stringify }}, es_type: "keyword"
+
     destroy_callback({{ foreign_key.id.symbolize }}, {{dependent}})
 
     {% if create_index %}
@@ -19,99 +47,149 @@ module RethinkORM::Associations
     {% end %}
 
     # Retrieves the parent relationship
-    def {{ method_name.id }} : {{ class_name }}?
-      parent = @{{ assoc_var }}
-      key = self.{{ foreign_key.id }}
-
-      return parent if parent
-
-      self.{{ assoc_var }} = key ? {{ class_name }}.find(key) : nil
+    def {{ method_name.id }} : {{ class_name }} | Nil
+      @{{ assoc_var.id }} ||= {{ class_name }}.find_one({{ primary_key.id }}: self.{{ foreign_key.id }})
+      if (parent = @{{ assoc_var.id }}) && (key = parent.{{ primary_key.id }})
+        self.{{ foreign_key.id }} ||= key
+        parent
+      end
     end
 
     def {{ method_name.id }}! : {{ class_name }}
       parent = @{{ assoc_var }}
-      key = self.{{ foreign_key.id }}
-
       return parent if parent
+
+      key = self.{{ foreign_key.id }}
       raise RethinkORM::Error.new("No {{ foreign_key.id }} set") unless key
 
-      self.{{ assoc_var }} = {{ class_name }}.find!(key)
+      @{{ assoc_var }} = {{ class_name }}.find_one!({{ primary_key.id }}: key)
     end
 
     # Sets the parent relationship
-    def {{ method_name.id }}=(parent : {{ class_name }})
-      self.{{ assoc_var }} = parent
-      self.{{ foreign_key.id }} = parent.{{ primary_key.id }}.as({{ foreign_type }})
+    def {{ method_name.id }}=(parent : {{ class_name }}{% unless presence %} | Nil{% end %})
+      @{{ assoc_var }} = parent
+      {% if presence %}\
+        self.{{ foreign_key.id }} = parent.{{ primary_key.id }}.as({{ primary_type }})
+      {% else %}\
+        self.{{ foreign_key.id }} = parent ? parent.{{ primary_key.id }}.as({{ primary_type }}) : nil
+      {% end %}\
     end
 
     def reset_associations
-      self.{{ assoc_var }} = nil
+      @{{ assoc_var }} = nil
     end
 
     # Look up instances of this model dependent on the foreign key
     def self.by_{{ foreign_key.id }}(id)
-      if self.has_index?({{ foreign_key.id.stringify }})
-        self.get_all([id], index: {{ foreign_key.id.stringify }})
+      if self.has_index?({{ foreign_key.id.symbolize }})
+        self.get_all([id], index: {{ foreign_key.id.symbolize }})
       else
         self.where({{ foreign_key.id }}: id)
       end
     end
+
+    {% if dbg %}
+      {% debug %}
+    {% end %}
   end
 
-  macro has_one(assoc, dependent = :none, create_index = false, foreign_key = nil, foreign_type = nil, primary_key = nil, presence = false)
+  # Specifies a one-to-one association with another class. This method should only be used if the
+  # other class contains the foreign key.
+  #
+  # Properties:
+  # `assoc`
+  # :    the method name and type (`name : Type`). An additional field will be created on the model
+  #      called {{ method_name }}_id which will correspond to the parent class' ID.
+  #
+  # `dependent`
+  # :    What do do when the parent record is destroyed. Valid options are `:cascade`, `:destroy`, or `:none`
+  #
+  # `create_index`
+  # :    Whether or not to tag this record as a secondary index.
+  #
+  # `foreign_key`
+  # :    Specify the foreign key used for the association. By default this is guessed to be the name of
+  #      the association with an `_id` suffix. So a class that defines a `has_one Person` association
+  #      will use `person_id` as the default foreign_key. Similarly, `has_one favorite_person : Person`,
+  #      will use a foreign key of `favorite_person_id`.
+  #
+  # `primary_key`
+  # :    Specify the method that returns the primary key of associated object used for the association.
+  #      By default this is `id`.
+  #
+  # `primary_type`
+  # :    Specify the class of the `primary_key` if it is not `String` (the default).
+  #
+  macro has_one(assoc, dependent = :none, create_index = false, foreign_key = nil, primary_key = nil, primary_type = nil, dbg = false)
     {% method_name = assoc.var %}
-    {% class_name = assoc.type %}
+    {% id_method_name = method_name.id + "_id" %}
+    {% class_name = assoc.type.stringify.split(" | ").first.id %}
+    {% presence = !assoc.type.stringify.ends_with?("Nil") %}
     {% foreign_key ||= method_name.id + "_id" %}
-    {% foreign_type ||= String %}
+    {% primary_type ||= String %}
     {% primary_key ||= "id".id %}
-    {% assoc_var = "__#{foreign_key.id}".id %}
+    {% assoc_var = "__#{method_name.id}".id %}
+    {% assoc_var_id = "__#{method_name.id}_id".id %}
 
-    attribute {{ foreign_key.id }} : {{ foreign_type }} {% unless presence %} | Nil {% end %}
-    property {{ assoc_var }} : {{ class_name }}?
-    destroy_callback({{ foreign_key.id.symbolize }}, {{dependent}})
+    @{{ assoc_var }} : {{ class_name }}?
 
-    {% if create_index %}
-      secondary_index({{ foreign_key.id }})
-    {% end %}
+    # Retrieves the child relationship
+    def {{ method_name.id }} : {{ class_name }} | Nil
+      child = @{{ assoc_var }}
+      return child unless child.nil?
+
+      key = self.{{ primary_key.id }}
+      @{{ assoc_var }} = key ? {{ class_name }}.find_one({{ foreign_key.id }}: key) : nil
+    end
 
     # Get cached child or attempt to load an associated {{method_name.id}}
-    def {{ method_name.id }} : {{ class_name }}?
-      key = self.{{ foreign_key.id }}
-      child = @{{ assoc_var }}
-      return child unless child.nil?
-
-      self.{{ assoc_var }} = key {% if foreign_type == String %}&& !key.empty?{% end %} ? {{ class_name }}.find(key) : nil
-    end
-
     def {{ method_name.id }}! : {{ class_name }}
-      key = self.{{ foreign_key.id }}
       child = @{{ assoc_var }}
       return child unless child.nil?
-      raise RethinkORM::Error.new("No {{ foreign_key.id }} set") unless key
 
-      self.{{ assoc_var }} = {{ class_name }}.find!(key)
+      key = self.{{ primary_key.id }}
+      raise RethinkORM::Error.new("No {{ primary_key.id }} set") unless key
+
+      @{{ assoc_var }} = {{ class_name }}.find_one!({{ foreign_key.id }}: key)
     end
 
-    def {{ method_name.id }}=(child)
-      self.{{ assoc_var }} = child
-      self.{{ foreign_key.id }} = child.{{ primary_key.id }}
+    # Sets the child relationship
+    def {{ method_name.id }}=(child : {{ class_name }}{% unless presence %} | Nil{% end %})
+      @{{ assoc_var }} = child
+
+      key = self.{{ primary_key.id }}
+      raise RethinkORM::Error.new("No {{ primary_key.id }} set") unless key
+
+      child.{{ foreign_key.id }} = key
+      child.save!
+
+      child
     end
 
     def reset_associations
-      self.{{ assoc_var }} = nil
+      @{{ assoc_var }} = nil
     end
+
+    {% if dbg %}
+      {% debug %}
+    {% end %}
   end
 
   # Must be used in conjunction with the belongs_to macro
-  macro has_many(child_class, collection_name = nil, dependent = :none, foreign_key = nil)
-    {% child_collection = (collection_name ? collection_name : child_class + 's').underscore.downcase %}
-    {% association_method = child_collection.id.symbolize %}
+  macro has_many(assoc, dependent = :none, foreign_key = nil, dbg = nil)
+    {% method_name = assoc.var %}
+    {% class_name = assoc.type.stringify.split(" | ").first.id %}
+    {% association_method = method_name.id.symbolize %}
 
     destroy_callback({{association_method}}, {{ dependent }})
 
-    def {{ child_collection.id }}
-      RethinkORM::AssociationCollection(self, {{ child_class }}).new(self, {{ foreign_key }})
+    def {{ method_name.id }}
+      RethinkORM::AssociationCollection(self, {{ class_name.id }}).new(self, {{ foreign_key }})
     end
+
+    {% if dbg %}
+      {% debug %}
+    {% end %}
   end
 
   # Generate destroy callbacks for dependent associations

--- a/src/rethinkdb-orm/connection.cr
+++ b/src/rethinkdb-orm/connection.cr
@@ -74,7 +74,12 @@ module RethinkORM
           Log.warn { "attempt #{attempt} retrying query" }
         }
       ) do
-        query.run(self.db, **options)
+        Log.with_context do
+          reql = query.to_reql
+          Log.context.set(db: self.db.hash.to_s, type: query.class.to_s, query: reql.to_s)
+          Log.debug { "Running query" }
+          query.run(self.db, **options)
+        end
       end
     end
 

--- a/src/rethinkdb-orm/persistence.cr
+++ b/src/rethinkdb-orm/persistence.cr
@@ -205,7 +205,6 @@ module RethinkORM::Persistence
   protected def __create(**options)
     run_create_callbacks do
       run_save_callbacks do
-        pp self
         return false unless valid?
 
         # TODO: Allow user to tag an attribute as primary key.

--- a/src/rethinkdb-orm/persistence.cr
+++ b/src/rethinkdb-orm/persistence.cr
@@ -183,7 +183,7 @@ module RethinkORM::Persistence
         response = Connection.raw_json(self.to_json) do |q, doc|
           q.table(@@table_name)
             .get(@id)
-            .update(doc, **options)
+            .replace(doc, **options) # Replace allows fields to be set to null
         end
 
         # TODO: Extend active-model to include previous changes
@@ -205,6 +205,7 @@ module RethinkORM::Persistence
   protected def __create(**options)
     run_create_callbacks do
       run_save_callbacks do
+        pp self
         return false unless valid?
 
         # TODO: Allow user to tag an attribute as primary key.

--- a/src/rethinkdb-orm/queries.cr
+++ b/src/rethinkdb-orm/queries.cr
@@ -72,6 +72,30 @@ module RethinkORM::Queries
       self.from_trusted_json(result.to_json) unless result.raw.nil?
     end
 
+    def self.find_one!(attrs : Hash, **options)
+      document = find_one(attrs, **options)
+      raise RethinkORM::Error::DocumentNotFound.new("Attributes don't match document: #{attrs}") unless document
+      document
+    end
+
+    def self.find_one(attrs : Hash, **options)
+      result = table_query(**options) do |q|
+        q.filter(attrs).coerce_to("array").nth(0)
+      end
+
+      self.from_trusted_json(result.to_json) unless result.raw.nil?
+    rescue
+      nil
+    end
+
+    def self.find_one(**attrs)
+      find_one(attrs.to_h)
+    end
+
+    def self.find_one!(**attrs)
+      find_one!(attrs.to_h)
+    end
+
     # Look up document by id
     #
     def self.find_all(ids : Array | Tuple, **options)

--- a/src/rethinkdb-orm/utils/association_collection.cr
+++ b/src/rethinkdb-orm/utils/association_collection.cr
@@ -1,14 +1,17 @@
 require "../index"
 
 class RethinkORM::AssociationCollection(Owner, Target)
+  include Enumerable(Target)
+
   private getter owner : Owner
   private getter foreign_key : String
 
   delegate :find, :find!, to: Target
-  forward_missing_to all
+
+  delegate :each, to: :all
 
   def initialize(@owner, foreign_key = nil)
-    @foreign_key = !foreign_key ? "#{Owner.table_name}_id" : foreign_key
+    @foreign_key = !foreign_key ? "#{Owner.table_name}_id" : foreign_key.to_s
   end
 
   def all


### PR DESCRIPTION
Trying to create an association in which the foreign key was anything other than a String was failing, so this fixes that by allowing users to set a `foreign_key_type` where appropriate. Ideally it would be nice to have this be done automagically, but idk if that's possible currently.