### PR TITLE
refactor(persistence): slight improvment to persistence errors

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rethinkdb-orm
-version: 3.1.2
+version: 3.2.0
 license: MIT
 
 authors:

--- a/spec/error_spec.cr
+++ b/spec/error_spec.cr
@@ -1,0 +1,19 @@
+require "./spec_helper"
+
+class RethinkORM::Error
+  describe DocumentInvalid do
+    it "#errors" do
+      m = ModelWithValidations.new("")
+      m.valid?.should be_false
+      e = DocumentInvalid.new(m)
+      e.errors.should eq [{field: :name, message: "is required"}, {field: :age, message: "must be greater than 20"}]
+    end
+
+    it "#to_s" do
+      m = ModelWithValidations.new("")
+      m.valid?.should be_false
+      e = DocumentInvalid.new(m)
+      e.to_s.should eq "name is required, age must be greater than 20"
+    end
+  end
+end

--- a/src/rethinkdb-orm/error.cr
+++ b/src/rethinkdb-orm/error.cr
@@ -15,19 +15,33 @@ class RethinkORM::Error < Exception
   end
 
   class DocumentInvalid < Error
-    getter model
+    getter model : RethinkORM::Base
+    getter errors : Array(NamedTuple(field: Symbol, message: String))
 
-    def initialize(@model : RethinkORM::Base, message)
-      super(message)
-    end
-
-    def inspect_errors
-      @model.errors.map do |e|
+    def initialize(@model, message = "Document has invalid fields")
+      @errors = @model.errors.map do |e|
         {
           field:   e.field,
           message: e.message,
         }
       end
+
+      super(message)
+    end
+
+    def to_s(io : IO)
+      remaining = errors.size
+      errors.each do |error|
+        remaining -= 1
+        io << error[:field].to_s
+        io << " " << error[:message]
+        io << ", " unless remaining.zero?
+      end
+    end
+
+    @[Deprecated("Use `errors` instead")]
+    def inspect_errors
+      errors
     end
   end
 

--- a/src/rethinkdb-orm/persistence.cr
+++ b/src/rethinkdb-orm/persistence.cr
@@ -40,20 +40,21 @@ module RethinkORM::Persistence
       @@uuid_generator = generator
     end
 
-    # Creates the model
+    # Creates the model.
     #
-    # Raises a RethinkORM::Error::DocumentNotSaved if failed to created
+    # See `#save!`
     def self.create!(**attributes)
-      document = new(**attributes)
-      raise RethinkORM::Error::DocumentNotSaved.new("Failed to create document!") unless document.save
-      document
+      new(**attributes).save!
     end
 
-    # Creates the model
+    # Creates the model.
     #
+    # Persistence can be confirmed via `#persisted?`
     def self.create(**attributes)
       document = new(**attributes)
-      document.save
+      begin
+        document.save!
+      end
       document
     end
 
@@ -71,44 +72,42 @@ module RethinkORM::Persistence
   # If the model is new, a record gets created in the database, otherwise
   # the existing record gets updated.
   def save(**options)
-    raise RethinkORM::Error::DocumentNotSaved.new("Cannot save a destroyed document!") if destroyed?
-
-    new_record? ? __create(**options) : __update(**options)
+    save!(**options)
+    true
+  rescue RethinkORM::Error
+    false
   end
 
   # Saves the model.
   #
   # If the model is new, a record gets created in the database, otherwise
   # the existing record gets updated.
-  # Raises RethinkORM::Error:DocumentInvalid on validation failure
+  #
+  # Raises
+  # - `RethinkORM::Error:DocumentNotSaved` if was document was destroyed before save
+  # - `RethinkORM::Error:DocumentNotSaved` if was document was not saved by RethinkDB
+  # - `RethinkORM::Error:DocumentInvalid` on validation failures
   def save!(**options)
-    raise RethinkORM::Error::DocumentInvalid.new(self, "Failed to save the document") unless self.save(**options)
-    self
+    raise RethinkORM::Error::DocumentNotSaved.new("Cannot save a destroyed document!") if destroyed?
+    new_record? ? __create(**options) : __update(**options)
   end
 
   # Updates the model
   #
   # Non-atomic updates are required for multidocument updates
   def update(**attributes)
-    assign_attributes(**attributes)
-    save
+    update(**attributes)
+    true
+  rescue RethinkORM::Error
+    false
   end
 
   # Updates the model in place
   #
-  # Throws RethinkORM::Error::DocumentInvalid on update failure
+  # Raises `RethinkORM::Error::DocumentInvalid` on update failure
   def update!(**attributes)
-    updated = self.update(**attributes)
-    raise RethinkORM::Error::DocumentInvalid.new(self, "Failed to update the document") unless updated
-    self
-  end
-
-  # Serialization of a subset of the model's attributes.
-  #
-  # FIXME: Optimise
-  protected def subset_json(fields : Enumerable(String) | Enumerable(Symbol))
-    string_keys = fields.is_a?(Enumerable(String)) ? fields : fields.map(&.to_s)
-    JSON.parse(self.to_json).as_h.select!(string_keys).to_json
+    assign_attributes(**attributes)
+    save!
   end
 
   # Atomically update specified fields, without running callbacks
@@ -154,9 +153,9 @@ module RethinkORM::Persistence
 
   # Reload the model in place.
   #
-  # Throws
-  # - RethinkORM::Error::DocumentNotSaved : If document was not previously persisted
-  # - RethinkORM::Error::DocumentNotFound : If document fails to load
+  # Raises
+  # - `RethinkORM::Error::DocumentNotSaved` if document was not previously persisted
+  # - `RethinkORM::Error::DocumentNotFound` if document fails to load
   def reload!
     raise RethinkORM::Error::DocumentNotSaved.new("Cannot reload unpersisted document") unless persisted?
 
@@ -171,14 +170,22 @@ module RethinkORM::Persistence
     self
   end
 
+  # Serialization of a subset of the model's attributes.
+  #
+  # FIXME: Optimise
+  protected def subset_json(fields : Enumerable(String) | Enumerable(Symbol))
+    string_keys = fields.is_a?(Enumerable(String)) ? fields : fields.map(&.to_s)
+    JSON.parse(self.to_json).as_h.select!(string_keys).to_json
+  end
+
   # Internal update function, runs callbacks and pushes update to RethinkDB
   #
-  protected def __update(**options)
-    return true unless changed?
+  private def __update(**options)
+    return self unless changed?
 
     run_update_callbacks do
       run_save_callbacks do
-        return false unless valid?
+        raise RethinkORM::Error::DocumentInvalid.new(self) unless valid?
 
         response = Connection.raw_json(self.to_json) do |q, doc|
           q.table(@@table_name)
@@ -194,24 +201,24 @@ module RethinkORM::Persistence
         created = response["created"]?.try(&.as_i?) || 0
         success = replaced > 0 || created > 0 || updated > 0 || unchanged == 1
 
-        clear_changes_information if success
-        success
+        raise RethinkORM::Error::DocumentNotSaved.new("Failed to update document") unless success
+
+        clear_changes_information
+        self
       end
     end
   end
 
   # Internal create function, runs callbacks and pushes new model to RethinkDB
   #
-  protected def __create(**options)
+  private def __create(**options)
     run_create_callbacks do
       run_save_callbacks do
-        return false unless valid?
+        raise RethinkORM::Error::DocumentInvalid.new(self) unless valid?
 
         # TODO: Allow user to tag an attribute as primary key.
         #       Requires either changing default primary key or using secondary index
-        id_local = @id
-
-        @id = @@uuid_generator.next(self) if id_local.nil? || id_local.empty?
+        @id = @@uuid_generator.next(self) if @id.presence.nil?
 
         response = Connection.raw_json(self.to_json) do |q, doc|
           q.table(@@table_name).insert(doc, **options)
@@ -222,19 +229,18 @@ module RethinkORM::Persistence
 
         success = (response["inserted"]?.try(&.as_i?) || 0) > 0
 
-        if success
-          clear_changes_information
-          self._new_flag = false
-        end
+        raise RethinkORM::Error::DocumentNotSaved.new("Failed to create document") unless success
 
-        success
+        clear_changes_information
+        self._new_flag = false
+        self
       end
     end
   end
 
   # Delete document in table, update model metadata
   #
-  protected def __delete
+  private def __delete
     response = Connection.raw do |q|
       q.table(@@table_name)
         .get(@id)


### PR DESCRIPTION
- Errors are now more fine-grained for `update!` and `save!`
- `RethinkORM::Error::DocumentInvalid#to_s` pretty prints validation errors
- `RethinkORM::Error::DocumentInvalid#inspect_errors` deprecated in favour of `RethinkORM::Error::DocumentInvalid#errors`

Component of #17