### PR TITLE
style: fix a set of lints

### DIFF
--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,0 +1,3 @@
+dependencies:
+  retriable:
+    github: Sija/retriable.cr

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rethinkdb-orm
-version: 3.2.3
+version: 3.2.4
 license: MIT
 crystal: ">= 0.36.1"
 

--- a/spec/persistence_spec.cr
+++ b/spec/persistence_spec.cr
@@ -109,7 +109,7 @@ describe RethinkORM::Persistence do
 
     models = BasicModel.all.to_a
     models.size.should eq 5
-    models.all? { |m| m.name == name }.should be_true
+    models.all?(&.name.==(name)).should be_true
 
     BasicModel.clear
     BasicModel.count.should eq 0

--- a/spec/queries_spec.cr
+++ b/spec/queries_spec.cr
@@ -10,7 +10,7 @@ describe RethinkORM::Queries do
 
     models = BasicModel.all.to_a
     models.size.should eq num_documents
-    models.all? { |m| m.name == "Psyduck" }.should be_true
+    models.all?(&.name.==("Psyduck")).should be_true
   end
 
   it "#find!" do
@@ -143,7 +143,7 @@ describe RethinkORM::Queries do
 
     get_tree_ids = ->(root_id : String) {
       # Refer to ./spec_models for `Tree#by_root_id` query
-      Tree.by_root_id(root_id).to_a.compact_map(&.id).sort
+      Tree.by_root_id(root_id).to_a.compact_map(&.id).sort!
     }
 
     # Check the correct

--- a/src/rethinkdb-orm/connection.cr
+++ b/src/rethinkdb-orm/connection.cr
@@ -156,7 +156,7 @@ module RethinkORM
     #
     protected def self.create_index_queries(indices, database = settings.db)
       # Group index queries by table
-      indices.group_by { |index| index[:table] }.transform_values do |queries|
+      indices.group_by(&.[:table]).transform_values do |queries|
         queries.map do |index|
           table = index[:table]
           field = index[:field]

--- a/src/rethinkdb-orm/validators/unique.cr
+++ b/src/rethinkdb-orm/validators/unique.cr
@@ -8,9 +8,9 @@ module RethinkORM::Validators
       validate "#{ {{ field }} } should be unique", ->(this: self) do
         {% if scope.empty? %}
           {% scope = [field] %}
-          {% proc_return_type = FIELDS[field.id][:klass].union_types.reject { |t| t == Nil }.join('|').id %}
+          {% proc_return_type = FIELDS[field.id][:klass].union_types.reject(&.==(Nil)).join('|').id %}
         {% else %}
-          {% proc_return_type = "Tuple(#{scope.map { |s| FIELDS[s.id][:klass].union_types.reject { |t| t == Nil }.join('|').id }.join(", ").id})".id %}
+          {% proc_return_type = "Tuple(#{scope.map { |s| FIELDS[s.id][:klass].union_types.reject(&.==(Nil)).join('|').id }.join(", ").id})".id %}
         {% end %}
 
         # Return if any values are nil
@@ -20,8 +20,8 @@ module RethinkORM::Validators
 
         # Construct proc type fron scope array (forgive me mother, for I have sinned)
         # Arguments are not-nillable as nil status is checked above.
-        {% proc_arg_type = "#{scope.map { |s| FIELDS[s.id][:klass].union_types.reject { |t| t == Nil }.join('|').id }.join(", ").id}".id %}
-        {% signature = "#{scope.map { |s| "#{s.id}: #{FIELDS[s.id][:klass].union_types.reject { |t| t == Nil }.join('|').id}" }.join(", ").id}".id %}
+        {% proc_arg_type = "#{scope.map { |s| FIELDS[s.id][:klass].union_types.reject(&.==(Nil)).join('|').id }.join(", ").id}".id %}
+        {% signature = "#{scope.map { |s| "#{s.id}: #{FIELDS[s.id][:klass].union_types.reject(&.==(Nil)).join('|').id}" }.join(", ").id}".id %}
 
         # Handle Transformation block/callback
         {% if transform %}


### PR DESCRIPTION
- Revert the removal of `shard.override.yml` to maintain backwards compatibility.
- Fix a set of ameba lints.