### PR TITLE
Fix tally spec

### DIFF
--- a/spec/queries_spec.cr
+++ b/spec/queries_spec.cr
@@ -78,6 +78,8 @@ describe RethinkORM::Queries do
     end
 
     it "tallys the documents with specific attributes" do
+      BasicModel.clear
+
       num_correct = 3
       num_incorrect = 4
       correct_name = Faker::Name.name


### PR DESCRIPTION
Addresses an issue where specs would intermittently fail when run under random order due to an undefined entry state.